### PR TITLE
Fix of InvalidOperationException: Operations that change non-concurre…

### DIFF
--- a/src/Phork.Blazor.Reactivity/Services/CollectionObserver.cs
+++ b/src/Phork.Blazor.Reactivity/Services/CollectionObserver.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Collections.Specialized;
 using Phork.Blazor.Lifecycle;
 
@@ -8,7 +8,7 @@ namespace Phork.Blazor.Services;
 internal class CollectionObserver : ICollectionObserver
 {
     private bool isDisposed;
-    private readonly Dictionary<INotifyCollectionChanged, NotifyCollectionChangedElement> elements = new();
+    private readonly ConcurrentDictionary<INotifyCollectionChanged, NotifyCollectionChangedElement> elements = new();
 
     public event EventHandler? ObservedCollectionChanged;
 
@@ -16,12 +16,7 @@ internal class CollectionObserver : ICollectionObserver
     {
         this.AssertNotDisposed();
 
-        if (!this.elements.TryGetValue(collection, out var element))
-        {
-            element = new NotifyCollectionChangedElement(collection, this.OnElementCollectionChanged);
-
-            this.elements[collection] = element;
-        }
+        var element = this.elements.GetOrAdd(collection, c => new NotifyCollectionChangedElement(collection, this.OnElementCollectionChanged));
 
         element.Touch();
     }

--- a/src/Phork.Blazor.Reactivity/Services/PropertyObserver.cs
+++ b/src/Phork.Blazor.Reactivity/Services/PropertyObserver.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using Phork.Blazor.Lifecycle;
 
@@ -9,7 +9,7 @@ internal class PropertyObserver : IPropertyObserver
 {
     private bool isDisposed;
 
-    private readonly Dictionary<INotifyPropertyChanged, NotifyPropertyChangedElement> elements = new();
+    private readonly ConcurrentDictionary<INotifyPropertyChanged, NotifyPropertyChangedElement> elements = new();
 
     public event EventHandler? ObservedPropertyChanged;
 
@@ -17,13 +17,8 @@ internal class PropertyObserver : IPropertyObserver
     {
         this.AssertNotDisposed();
 
-        if (!this.elements.TryGetValue(notifier, out var element))
-        {
-            element = new NotifyPropertyChangedElement(notifier, this.OnElementPropertyChanged);
-
-            this.elements[notifier] = element;
-        }
-
+        var element = this.elements.GetOrAdd(notifier, n => new NotifyPropertyChangedElement(notifier, this.OnElementPropertyChanged));
+        
         element.Observe(propertyName);
     }
 


### PR DESCRIPTION
…nt collections must have exclusive access.

Affected Phork Version 1.1.2

Sometimes `Observed(...)` and `ObservedCollection(...)` is throwing a concurrent exception if it's called a lot because the Dictionary in PropertyObserver and CollectionObserver is modiefied while it is searched for an element.

https://github.com/phorks/phork-blazor-reactivity/blob/101e859f5adf4ef20e8c8488d55bfe7254529dc9/src/Phork.Blazor.Reactivity/Services/PropertyObserver.cs#L20

This is the callstack from the exception:

```c#
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
   at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
   at Phork.Blazor.ReactivityManager.Observe[T](Expression`1 valueAccessor, Boolean ensureAccessible)
   at Phork.Blazor.ReactivityManager.Observed[T](Expression`1 valueAccessor)
   at Phork.Blazor.ReactiveComponentBase.Observed[T](Expression`1 valueAccessor)
   at Company.App.Components.CommonComponentBase.<>c__DisplayClass93_0`2.<registerSingleDocumentBindings>g__announceObservables|0()
   at Company.App.Components.CommonComponentBase.ConfigureBindings()
   at Phork.Blazor.ReactiveComponentBase.Phork.Blazor.IReactiveComponent.ConfigureBindings()
   at Phork.Blazor.ReactivityManager.NotifyCycleEnded()
   at Phork.Blazor.ReactivityManager.<>c__DisplayClass20_0.<ConfigureComponentBase>g__NewRenderFragment|0(RenderTreeBuilder builder)
   at Microsoft.AspNetCore.Components.Rendering.ComponentState.RenderIntoBatch(RenderBatchBuilder batchBuilder, RenderFragment renderFragment, Exception& renderFragmentException)
```